### PR TITLE
Minor comment error fix and speed_byte mapping fix.

### DIFF
--- a/DCCHardware.c
+++ b/DCCHardware.c
@@ -10,7 +10,7 @@
       *dos_send_premable: A packet has been made available, and so we should broadcast the preamble: 14 '1's in a row
       *dos_send_bstart: Each data uint8_t is preceded by a '0'
       *dos_send_uint8_t: Sending the current data uint8_t
-      *dos_end_bit: After the final uint8_t is sent, send a '0'.
+      *dos_end_bit: After the final uint8_t is sent, send a '1'.
 */                 
 typedef enum  {
   dos_idle,

--- a/examples/CmdrArduino_minimum/CmdrArduino_minimum.ino
+++ b/examples/CmdrArduino_minimum/CmdrArduino_minimum.ino
@@ -42,14 +42,23 @@ void loop() {
 
   //handle reading throttle
   analog_value = analogRead(0);
-  speed_byte = map(analog_value, 0, 1023, -127, 127); //Remap the analog input from [0 to 1023] into [-127 to 127]
+  const uint16_t dead_zone_width = 10;
+  if(analog_value <= (511-dead_zone_width))
+  {
+    speed_byte = map(analog_value, 0, 511-(.5*dead_zone_width), -127, -2)
+  }
+  else if(analog_value >= (512+dead_zone_width))
+  {
+    speed_byte = map(analog_value, 511+(.5*dead_zone_width), 1023, 2, 127)
+  }
+  else
+  {
+    if(old_speed > 0) speed_byte = 1;
+    else speed_byte = -1; 
+  }
+
   if(speed_byte != old_speed)
   {
-    if(speed_byte == 0) //this would be treated as an e-stop!
-    {
-      if(old_speed > 0) speed_byte = 1;
-      else speed_byte = -1;
-    }
     Serial.print("analog = ");
     Serial.println(analog_value, DEC);
     Serial.print("digital = ");
@@ -58,6 +67,6 @@ void loop() {
     old_speed = speed_byte;
   }
   dps.update();
-  
+
   ++count;
 }

--- a/examples/CmdrArduino_minimum/CmdrArduino_minimum.ino
+++ b/examples/CmdrArduino_minimum/CmdrArduino_minimum.ino
@@ -42,7 +42,7 @@ void loop() {
 
   //handle reading throttle
   analog_value = analogRead(0);
-  speed_byte = (analog_value >> 2)-127 ; //divide by four to take a 0-1023 range number and make it 1-126 range.
+  speed_byte = map(analog_value, 0, 1023, -127, 127); //Remap the analog input from [0 to 1023] into [-127 to 127]
   if(speed_byte != old_speed)
   {
     if(speed_byte == 0) //this would be treated as an e-stop!

--- a/examples/CmdrArduino_minimum/CmdrArduino_minimum.ino
+++ b/examples/CmdrArduino_minimum/CmdrArduino_minimum.ino
@@ -43,11 +43,11 @@ void loop() {
   //handle reading throttle
   analog_value = analogRead(0);
   const uint16_t dead_zone_width = 10;
-  if(analog_value <= (511-dead_zone_width))
+  if(analog_value <= (511-(.5*dead_zone_width)))
   {
     speed_byte = map(analog_value, 0, 511-(.5*dead_zone_width), -127, -2)
   }
-  else if(analog_value >= (512+dead_zone_width))
+  else if(analog_value >= (511+(.5*dead_zone_width)))
   {
     speed_byte = map(analog_value, 511+(.5*dead_zone_width), 1023, 2, 127)
   }


### PR DESCRIPTION
The first commit is a minor one in which the comment incorrectly stated the end_bit is a 0, when it is a 1.

The second commit I found to be a more robust method of assigning the speed_byte based on the 0-1023 analog input values.  I found the first method was producing errors for me.
